### PR TITLE
fix: add app-port env to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node ./build/app.cjs",
     "dev": "tsx watch src/app.ts",
     "lint": "eslint --ext .ts src",
-    "test": "NODE_ENV=test vitest run",
+    "test": "NODE_ENV=test APP_PORT=3000 vitest run",
     "test:watch": "NODE_ENV=test vitest",
     "test:coverage": "NODE_ENV=test vitest run --coverage"
   },


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Set the APP_PORT environment variable when running tests.