### PR TITLE
ci: add prisma generate step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+        
+      - name: Generate Prisma Client
+        run: npx prisma generate
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a step to generate the Prisma client using "npx prisma generate".